### PR TITLE
Only include sessions with a date from the naucse API

### DIFF
--- a/backend/cw_backend/courses/courses.py
+++ b/backend/cw_backend/courses/courses.py
@@ -97,7 +97,10 @@ class Course:
             }
 
             local_sessions = {str(s['slug']): s for s in raw.get('sessions', [])}
-            naucse_sessions = {str(s['slug']): s for s in nc.get('sessions', [])}
+            naucse_sessions = {
+                # Only include sessions with a date
+                str(s['slug']): s for s in nc.get('sessions', []) if 'date' in s
+            }
             self.sessions = []
             for slug in local_sessions.keys() | naucse_sessions.keys():
                 self.sessions.append(Session(


### PR DESCRIPTION
Not all sessions from naucse have a date. In Brno, we use a date-less first session for preparation: https://naucse.python.cz/2019/brno-jaro-2019-pondeli/

I guess it's OK to ignore these in the tool – at least for now. It would also be possible to include them, but I'm not sure how they should be sorted with respect to `local_sessions`.
