### PR TITLE
Separate logic behind `mandatory` flag and add new `top` flag.

### DIFF
--- a/backend/cw_backend/courses/session.py
+++ b/backend/cw_backend/courses/session.py
@@ -179,7 +179,7 @@ class TaskSection:
         self.data = {
             'task_item_type': 'section',
             'text_html': to_html(raw_item['section']),
-            'mandatory': bool(raw_item.get('mandatory', False)),
+            'top': bool(raw_item.get('top', False)),
         }
 
     def export(self):
@@ -187,10 +187,10 @@ class TaskSection:
 
     @property
     def first(self):
-      return self.data['mandatory']
+        return self.data['top']
 
     def set_number(self, counter):
-      pass
+        pass
 
 
 class Task:
@@ -205,6 +205,7 @@ class Task:
             'text_html': to_html(raw),
             'mandatory': bool(raw.get('mandatory', False)),
             'submit': bool(raw.get('submit', True)),
+            'top': bool(raw.get('top', False))
         }
 
     def export(self):
@@ -212,9 +213,9 @@ class Task:
 
     @property
     def first(self):
-      return self.data['mandatory']
+        return self.data['top']
 
     def set_number(self, counter):
-      number = next(counter)
-      self.data['number'] = number
-      self.data['id'] = str(self.id or f'{self.session_slug}-{number}')
+        number = next(counter)
+        self.data['number'] = number
+        self.data['id'] = str(self.id or f'{self.session_slug}-{number}')

--- a/backend/tests/data/sample_course/expected_export_detail.yaml
+++ b/backend/tests/data/sample_course/expected_export_detail.yaml
@@ -31,6 +31,7 @@ course_detail:
       submit: true
       task_item_type: task
       text_html: <p>Dělení? Znak ÷ se taky na klávesnici těžko píše (zvlášť na české). Jak se asi bude dělit?</p>
+      top: false
     - id: 1-instalace-1
       mandatory: false
       number: 1
@@ -39,6 +40,7 @@ course_detail:
       text_html: |-
         <p>Závorky v Pythonu fungují jako v matematice. Zkus pomocí Pythonu vypočítat: 3+(4+6)×8÷2−1 =</p>
         <p>Jak se to zapíše v Pythonu?</p>
+      top: false
     title_html: Lekce 1 – Instalace
   - date: '2018-03-14'
     has_tasks: false


### PR DESCRIPTION
Attempt to fix  #84 
`mandatory` flag now shows only the graphic hand next to the task while new `top` flag ensures the task is moved on the top of the list.