### PR TITLE
Render comments as markdown

### DIFF
--- a/backend/cw_backend/courses/helpers.py
+++ b/backend/cw_backend/courses/helpers.py
@@ -54,15 +54,17 @@ def parse_date(s):
     raise Exception(f'Invalid date format: {s!r}')
 
 
-def markdown_to_html(src):
+def markdown_to_html(src, enable_tables=True):
     from markdown import markdown
+    extensions = [
+        'markdown.extensions.fenced_code',
+        'mdx_linkify',
+    ]
+    if enable_tables:
+        extensions.append('markdown.extensions.tables')
     return markdown(
         src,
-        extensions=[
-            'markdown.extensions.fenced_code',
-            'markdown.extensions.tables',
-            'mdx_linkify',
-        ],
+        extensions=extensions,
         output_format='html5')
 
 

--- a/backend/cw_backend/courses/helpers.py
+++ b/backend/cw_backend/courses/helpers.py
@@ -64,3 +64,9 @@ def markdown_to_html(src):
             'mdx_linkify',
         ],
         output_format='html5')
+
+
+def escape_markdown(markdown_html):
+    import bleach
+    from bleach_allowlist import markdown_tags, markdown_attrs
+    return bleach.clean(markdown_html, markdown_tags, markdown_attrs)

--- a/backend/cw_backend/model/task_solution_comments.py
+++ b/backend/cw_backend/model/task_solution_comments.py
@@ -6,6 +6,7 @@ from operator import itemgetter
 from pymongo import ASCENDING as ASC
 from pymongo import ReturnDocument
 
+from ..courses.helpers import escape_markdown, markdown_to_html
 from ..util import smart_repr, to_oid, to_str
 
 
@@ -89,7 +90,7 @@ class TaskSolutionComment:
         data = {
             'id': self.id,
             'date': self.date.strftime('%Y-%m-%dT%H:%M:%SZ'),
-            'body': self.body,
+            'body': escape_markdown(markdown_to_html(self.body)),
             'author': {
                 'user_id': self.author_user_id,
                 'name': self.author_name,

--- a/backend/cw_backend/model/task_solution_comments.py
+++ b/backend/cw_backend/model/task_solution_comments.py
@@ -90,7 +90,7 @@ class TaskSolutionComment:
         data = {
             'id': self.id,
             'date': self.date.strftime('%Y-%m-%dT%H:%M:%SZ'),
-            'body': escape_markdown(markdown_to_html(self.body)),
+            'body': escape_markdown(markdown_to_html(self.body, enable_tables=False)),
             'author': {
                 'user_id': self.author_user_id,
                 'name': self.author_name,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,8 @@ aiohttp
 aiohttp_session
 https://github.com/messa/aiohttp-session-mongo/archive/master.zip#egg=aiohttp-session-mongo==0.0.1
 bcrypt
+bleach==3.2.1
+bleach-allowlist==1.0.3
 cchardet
 markdown
 motor

--- a/frontend/components/lesson/TaskComments.js
+++ b/frontend/components/lesson/TaskComments.js
@@ -64,7 +64,7 @@ export default class TaskComments extends React.Component {
                   <div>{comment.date.toString()}</div>
                   <Label>Verze {this.getCodeVersion(comment.date, codeVersions)}</Label>
                 </Comment.Metadata>
-                <Comment.Text>{comment.body}</Comment.Text>
+                <Comment.Text dangerouslySetInnerHTML={{__html: comment.body}} />
                 <Comment.Actions>
                   <Comment.Action
                     content='Odpovědět'
@@ -86,7 +86,7 @@ export default class TaskComments extends React.Component {
                           <div>{reply.date.toString()}</div>
                           <Label>Verze {this.getCodeVersion(reply.date, codeVersions)}</Label>
                         </Comment.Metadata>
-                        <Comment.Text>{reply.body}</Comment.Text>
+                        <Comment.Text dangerouslySetInnerHTML={{__html: reply.body}} />
                         <Comment.Actions>
                           <Comment.Action
                             content='Odpovědět'
@@ -124,5 +124,4 @@ export default class TaskComments extends React.Component {
       </div>
     )
   }
-
 }


### PR DESCRIPTION
When reviewing tasks, I often need to include snippets of code. Currently, it looks terrible, as there is no formatting.
This PR changes comments to be rendered with markdown. It also sanitizes the output, since comments can also be entered by untrusted users.

If you agree with it, I would also like to add some basic syntax highlighting (`highlight.js`).