### PR TITLE
Allow courses to stop registration

### DIFF
--- a/backend/cw_backend/courses/courses.py
+++ b/backend/cw_backend/courses/courses.py
@@ -122,6 +122,12 @@ class Course:
                 self.data['start_date'] = self.sessions[0].date
             if not self.data['end_date'] and self.sessions:
                 self.data['end_date'] = self.sessions[-1].date
+
+            if 'registration_end' in raw:
+                self.data['registration_end'] = parse_date(raw['registration_end'])
+            else:
+                self.data['registration_end'] = self.data['end_date']
+
         except Exception as e:
             raise Exception(f'Failed to load course from {course_file}: {e}') from e
 
@@ -138,6 +144,9 @@ class Course:
     def is_past(self):
         return self.data['end_date'] < date.today()
 
+    def allows_registration(self):
+        return self.data['registration_end'] >= date.today()
+
     def get_session_by_slug(self, slug):
         assert isinstance(slug, str)
         for session in self.sessions:
@@ -150,6 +159,8 @@ class Course:
             **self.data,
             'start_date': self.data['start_date'].isoformat(),
             'end_date': self.data['end_date'].isoformat(),
+            'registration_end': self.data['registration_end'].isoformat(),
+            'allows_registration': self.allows_registration(),
         }
         if sessions:
             d['sessions'] = [lesson.export(tasks=tasks) for lesson in self.sessions]

--- a/backend/cw_backend/views/users.py
+++ b/backend/cw_backend/views/users.py
@@ -22,10 +22,10 @@ async def assign_student_to_course(req):
     model = req.app['model']
     user = await model.users.get_by_id(session['user']['id'])
     courses = req.app['courses']
-    active_course_ids = [c.id for c in courses.get().list_active()]
     data = await req.json()
     course_id = data['course_id']
-    if course_id in active_course_ids and course_id not in user.attended_course_ids:
+    course = courses.get().get_by_id(course_id)
+    if course.allows_registration() and course_id not in user.attended_course_ids:
         await user.add_attended_courses([course_id], author_user_id=user.id)
     return web.json_response({
         'attended_course_ids': user.attended_course_ids,

--- a/data/2021_online_spring/course.yaml
+++ b/data/2021_online_spring/course.yaml
@@ -1,5 +1,6 @@
 id: online-2021-spring
 naucse_api_url: https://naucse.python.cz/v0/2021/online-jaro.json?2
+registration_end: 2021-03-21
 tasks_by_lesson_slug:
 
   "beginners/install":

--- a/frontend/pages/course.js
+++ b/frontend/pages/course.js
@@ -69,9 +69,6 @@ export default class extends React.Component {
       arrayContains(user['attended_course_ids'], courseId) ||
       arrayContains(user['coached_course_ids'], courseId)
     )
-    const now = new Date()
-    const courseEnd = new Date(course['end_date'])
-    const activeCourse = (courseEnd >= now)
     return (
       <Layout user={this.props.user} width={1000}>
 
@@ -88,7 +85,7 @@ export default class extends React.Component {
             className='course-description'
             dangerouslySetInnerHTML={{__html: course['description_html']}}
           />
-          {activeCourse && (
+          {course['allows_registration'] && (
             <div className='course-attend'>
               {attendError && (
                 <div>


### PR DESCRIPTION
The enrollment button is currently active while a course is running,
allowing random strangers to "enroll" when registration has already
ended.
This change should allow a course to set an end date for registrations,
limiting further attendance changes to admins.

This is added to the online course, which suffers from the problem.