### PR TITLE
Update course.yaml for olomouc

### DIFF
--- a/data/2021_pyladies_olomouc_autumn/course.yaml
+++ b/data/2021_pyladies_olomouc_autumn/course.yaml
@@ -6,5 +6,5 @@ tasks_by_lesson_slug:
   - file: tasks/1_install.yaml
   "beginners/hello-world":
   - file: tasks/2_first_app.yaml
-  "beginners/loops":
+  "beginners/while":
   - file: tasks/3_loops.yaml


### PR DESCRIPTION
I am to lazy to check the code, but i think that `slug` (e.g. `beginners/loops` or `beginners/while`) have to be in https://naucse.python.cz/v0/2021/pyladies-olomouc-podzim.json under selected session in materials.

Tested locally