### PR TITLE
Show a hint that a session has unreviewed solutions

### DIFF
--- a/backend/cw_backend/views/page_data.py
+++ b/backend/cw_backend/views/page_data.py
@@ -85,16 +85,17 @@ async def course_detail(req, params):
         if datetime.utcnow().strftime('%Y-%m-%d') <= '2018-10-30':
             await user.add_attended_courses([course.id], author_user_id=None)
 
-    if params.get('check-new-events'):
-        course_data = course.export(sessions=True, tasks=True)
-        for session in course_data['sessions']:
-            task_ids = [task['id'] for task in session['task_items'] if 'id' in task]
-            solutions = await model.task_solutions.find_by_course_and_task_ids(course_id=course.id,
-                                                                               task_ids=task_ids)
-            session['has-new-events'] = any(s.last_action == 'student' for s in solutions)
-        return course_data
-    else:
-        return course.export(sessions=True)
+        if params.get('check-new-events') and user.can_review_course(course.id):
+            course_data = course.export(sessions=True, tasks=True)
+            for session in course_data['sessions']:
+                task_ids = [task['id'] for task in session['task_items'] if 'id' in task]
+                solutions = await model.task_solutions.find_by_course_and_task_ids(
+                    course_id=course.id,
+                    task_ids=task_ids
+                )
+                session['has-new-events'] = any(s.last_action == 'student' for s in solutions)
+            return course_data
+    return course.export(sessions=True)
 
 
 @resolver

--- a/backend/cw_backend/views/page_data.py
+++ b/backend/cw_backend/views/page_data.py
@@ -85,7 +85,7 @@ async def course_detail(req, params):
         if datetime.utcnow().strftime('%Y-%m-%d') <= '2018-10-30':
             await user.add_attended_courses([course.id], author_user_id=None)
 
-        if params.get('check-new-events') and user.can_review_course(course.id):
+        if params.get('check-unreviewed') and user.can_review_course(course.id):
             course_data = course.export(sessions=True, tasks=True)
             for session in course_data['sessions']:
                 task_ids = [task['id'] for task in session['task_items'] if 'id' in task]
@@ -93,7 +93,8 @@ async def course_detail(req, params):
                     course_id=course.id,
                     task_ids=task_ids
                 )
-                session['has-new-events'] = any(s.last_action == 'student' for s in solutions)
+                session['unreviewed-count'] = sum(
+                    1 if s.last_action == 'student' else 0 for s in solutions)
             return course_data
     return course.export(sessions=True)
 

--- a/frontend/pages/course.js
+++ b/frontend/pages/course.js
@@ -21,7 +21,7 @@ export default class extends React.Component {
   static async getInitialProps({ req, query }) {
     const courseId = query.course
     const data = await fetchPageData(req, {
-      course: { 'course_detail': { 'course_id': courseId } },
+      course: { 'course_detail': { 'course_id': courseId, 'check-new-events': true } },
     })
     return { courseId, ...data }
   }
@@ -135,6 +135,7 @@ export default class extends React.Component {
 
               <h2 className='session-title'>
                 <span dangerouslySetInnerHTML={{__html: session['title_html']}} />
+                {session['has-new-events'] && <b title='V této lekci jsou neopravené úkoly'>*</b>}
               </h2>
               <div className='sessionDate'>{formatDate(session['date'])}</div>
 

--- a/frontend/pages/course.js
+++ b/frontend/pages/course.js
@@ -11,6 +11,18 @@ function arrayContains(array, item) {
   return array && array.indexOf(item) !== -1
 }
 
+function UnreviewedSolutionsHint(props) {
+  if (!props.session.hasOwnProperty('unreviewed-count')) return null;
+
+  const count = props.session['unreviewed-count'];
+  if (count > 0) {
+    return (
+        <b title={`V této lekci jsou neopravené úkoly (${count})`} className='notification'>&nbsp;(*{count})</b>
+    );
+  }
+  return null;
+}
+
 export default class extends React.Component {
 
   state = {
@@ -21,7 +33,7 @@ export default class extends React.Component {
   static async getInitialProps({ req, query }) {
     const courseId = query.course
     const data = await fetchPageData(req, {
-      course: { 'course_detail': { 'course_id': courseId, 'check-new-events': true } },
+      course: { 'course_detail': { 'course_id': courseId, 'check-unreviewed': true } },
     })
     return { courseId, ...data }
   }
@@ -135,7 +147,7 @@ export default class extends React.Component {
 
               <h2 className='session-title'>
                 <span dangerouslySetInnerHTML={{__html: session['title_html']}} />
-                {session['has-new-events'] && <b title='V této lekci jsou neopravené úkoly'>*</b>}
+                <UnreviewedSolutionsHint session={session} />
               </h2>
               <div className='sessionDate'>{formatDate(session['date'])}</div>
 


### PR DESCRIPTION
PyLadies participants often upload task solutions a long time after they were initially assigned. I'm finding myself going through each session over and over to see if there is any unreviewed solution (⬤).

This PR adds a simple notification (asterisk) to the course overview screen which immediately lets you know which sessions need review:
![image](https://user-images.githubusercontent.com/4539057/143496223-be2dca1b-e0e3-4bcc-9963-32e56c7c3d34.png)

The backend implementation is a bit messy, because `TaskSolution` does not store its corresponding session ID, so I have to match the task solutions manually.