### PR TITLE
Add syntax highlighting and line numbers to task solution code

### DIFF
--- a/frontend/components/CodeEditor.js
+++ b/frontend/components/CodeEditor.js
@@ -40,7 +40,6 @@ export default class extends React.Component {
   render() {
     const options = {
       mode: 'python',
-      theme: 'solarized',
       lineNumbers: true,
     }
     return (

--- a/frontend/components/Layout.js
+++ b/frontend/components/Layout.js
@@ -12,8 +12,6 @@ export default ({ children, user, activeItem, width }) => (
       <link rel="stylesheet" href="/static/main2.css" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.0/codemirror.min.css"
         integrity="sha256-I8NyGs4wjbMuBSUE40o55W6k6P7tu/7G28/JGUUYCIs=" crossOrigin="anonymous" />
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.0/theme/solarized.min.css"
-        integrity="sha256-v5CcBJnFb3uNFDq7uhR4sIS7yihsXlBxN+cwxjtzp7c=" crossOrigin="anonymous" />
     </Head>
 
     <Header user={user} activeItem={activeItem} />

--- a/frontend/components/lesson/TaskSolution.js
+++ b/frontend/components/lesson/TaskSolution.js
@@ -1,12 +1,40 @@
 import React from 'react'
 import { Label, Tab, Icon} from 'semantic-ui-react'
+import {Controlled as CodeMirror} from 'react-codemirror2'
+
+function SourceCode(props) {
+  const code = props.code;
+  const options = {
+    mode: 'python',
+    lineNumbers: true,
+    readOnly: 'nocursor',
+    scrollbarStyle: null,
+  };
+
+  return (
+      <>
+        <CodeMirror
+            value={code}
+            options={options}
+        />
+        <style jsx global>{`
+          .CodeMirror {
+            height: auto;
+          }
+          .CodeMirror-scroll {
+            overflow: hidden !important;
+          }
+        `}</style>
+      </>
+    );
+}
 
 export default class extends React.Component {
 
-  copyToClipboard = (e) => {
+  copyToClipboard = (code) => {
     var dummy = document.createElement('textarea')
     document.body.appendChild(dummy)
-    dummy.value = e.currentTarget.nextSibling.innerText
+    dummy.value = code
     dummy.select()
     document.execCommand('copy')
     document.body.removeChild(dummy)
@@ -20,30 +48,24 @@ export default class extends React.Component {
     const allVersions = taskSolution.all_versions
     if (!allVersions) return null
     const sortedVersions = allVersions.slice().sort(function (a, b) { return b.date.localeCompare(a.date) })
-    const copyToClipboard = this.copyToClipboard
     var cntr = sortedVersions.length
     const panes = sortedVersions.slice(0, 8).map(
-      function (v) {
-        name = 'Verze ' + cntr
+      (v) => {
+        const name = 'Verze ' + cntr
         cntr -= 1
         return {
           menuItem: name,
-          render: () => <Tab.Pane>
+          render: () => <Tab.Pane style={{padding: 0}}>
             <div className='TaskSolution'>
               <Label attached='bottom right'>{v.date}</Label>
               <Label
                 attached='bottom left'
                 as='button'
-                onClick={copyToClipboard}>
+                onClick={() => this.copyToClipboard(v.code)}>
                 <Icon name='copy'/>
                 <Label.Detail>Kopírovat</Label.Detail>
               </Label>
-              <pre>{v.code}</pre>
-              <style jsx>{`
-                .TaskSolution pre {
-                  overflow-x: auto;
-                }
-              `}</style>
+              <SourceCode code={v.code} />
             </div>
           </Tab.Pane>
         }


### PR DESCRIPTION
This PR adds syntax highlighting and line numbers to task solution displayed code.
I also removed the `solarized` theme, because I find it ugly :D But I can revert that if you want.

Not all submissions have to contain code, but I think that most of them do, so I don't think that it's worth it to do any "auto-detection" of Python. But if you want it, I can add it.

Before:
![image](https://user-images.githubusercontent.com/4539057/144578797-44582052-fb55-47cf-b5f6-37b78af9941c.png)

After:
![image](https://user-images.githubusercontent.com/4539057/144578745-6edfbbc7-56ae-4323-a01a-44b0612a7ad4.png)

In a follow-up PR, I want to add split-view diff between two submitted versions.

Fixes: https://github.com/messa/pyladies-courseware/issues/27
Fixes: https://github.com/messa/pyladies-courseware/issues/258