### PR TITLE
Make it possible to run frontend in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ run-mongod:
 	mkdir -p mongo_data
 	mongod --dbpath=mongo_data --bind_ip 127.0.0.1
 
+run-frontend-in-docker:
+	docker run --rm -it \
+		-v $(PWD)/frontend:/src \
+		-w /src \
+		--network=host \
+		node:16 \
+		bash -c "npm install; npm run dev"
+
 run-mongod-in-docker:
 	mkdir -p mongo_data
 	docker run --rm -it \

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ $ make run-backend
 $ make run-frontend
 ```
 
+Pokud z nějakého důvodu nechceš nebo nemůžeš pouštět MongoDB nebo instalovat balíčky
+pro Node.js přímo ve svém systému, můžeš tyto dvě komponenty spustit v kontejnerech
+pomocí `make run-mongod-in-docker` resp. `make run-frontend-in-docker`. Backend má vlastní
+virtuální prostředí a potřebuješ pro něj jen Python 3, takže pro backend tato možnost není.
+
 Otevři http://localhost:3000/
 
 | Port  | Služba


### PR DESCRIPTION
The motivation for this change is that Node.js in Fedora seems to be too new for this project. Version 18 we have does not work so it's necessary to run the frontend in a container with an older version of Node.

FTR, when I run the same with Node 18, I get:
```
up to date in 1m

43 packages are looking for funding
  run `npm fund` for details

> pyladies-courseware-frontend@1.0.0 dev
> node server

Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
The static directory has been deprecated in favor of the public directory. https://err.sh/vercel/next.js/static-dir-deprecated
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/src/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/src/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/src/node_modules/webpack/lib/NormalModule.js:471:10)
    at /src/node_modules/webpack/lib/NormalModule.js:503:5
    at /src/node_modules/webpack/lib/NormalModule.js:358:12
    at /src/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/src/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at Array.<anonymous> (/src/node_modules/loader-runner/lib/LoaderRunner.js:205:4) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.10.0
make: *** [Makefile:13: run-frontend-in-docker] Error 1
```

Cc @Disi77 @befeleme 