### PR TITLE
Show who reviewed a given task

### DIFF
--- a/backend/cw_backend/model/task_solutions.py
+++ b/backend/cw_backend/model/task_solutions.py
@@ -121,9 +121,12 @@ class TaskSolution:
         self.task_id = doc['task_id']
         self.user_id = doc['user_id']
         self.is_solved = None
+        self.reviewed_by = None
         self.current_version_id = str(doc['current_version_id']) if doc.get('current_version_id') else None
         if doc.get('marked_as_solved'):
             self.is_solved = doc['marked_as_solved']['solved']
+            if self.is_solved:
+                self.reviewed_by = doc['marked_as_solved']['by_user']['name']
         self.last_action = None
         if doc.get('last_action'):
             self.last_action = doc['last_action']['role']
@@ -193,6 +196,7 @@ class TaskSolution:
             'task_id': self.task_id,
             'user_id': self.user_id,
             'is_solved': self.is_solved,
+            'reviewed_by': self.reviewed_by,
             'last_action': self.last_action,
         }
 

--- a/frontend/components/TaskSubmission.js
+++ b/frontend/components/TaskSubmission.js
@@ -254,7 +254,7 @@ const TaskStatus = ({ taskSolution }) => {
   }
   if (taskSolution.is_solved) {
     content = '✓'
-    text = '- vyřešené'
+    text = '- vyřešené (' + taskSolution.reviewed_by + ')'
   }
   return (
     <span>

--- a/frontend/components/lesson/TaskReview.js
+++ b/frontend/components/lesson/TaskReview.js
@@ -305,7 +305,7 @@ const TaskStatus = ({ taskSolution }) => {
   }
   if (taskSolution.is_solved) {
     content = '✓'
-    text = '- označeno za vyřešené'
+    text = '- označeno za vyřešené (' + taskSolution.reviewed_by + ')'
   }
   return (
     <span>


### PR DESCRIPTION
When multiple teachers are reviewing the same course, it can be a bit confusing for the students, because they might now know who exactly reviewed their code, if there are no comments posted to it.

This PR renders the name of the reviewer, so that it is immediately visible.

- How the teacher sees it:
![image](https://github.com/user-attachments/assets/2982b83e-d3f0-4e88-8f08-8755c49dde2e)
- How the student sees it:
![image](https://github.com/user-attachments/assets/74b9b093-3027-496b-b36d-9946155ec857)
