### PR TITLE
Pydata 2025 prague materials

### DIFF
--- a/data/2025_pydata_praha_autumn/course.yaml
+++ b/data/2025_pydata_praha_autumn/course.yaml
@@ -5,7 +5,7 @@ end_date: 2025-12-24
 sessions:
 
   - title: Představení, Jupyter notebook, základy pandas
-    date: 15.9.2025
+    date: 2025-09-15
     slug: 1-predstaveni-jupyter-notebook-zaklady-pandas
     materials:
       - attachment: Instalace
@@ -16,7 +16,7 @@ sessions:
         url: https://pydatacz.github.io/pyladies-kurz/pydata/pandas-core/
 
   - title: Datové typy a základy vizualizace v pandas
-    date: 22.9.2025
+    date: 2025-09-22
     slug: 2-datove-typy-zaklady-vizualizace
     materials:
       - attachment: Pandas - datové typy a základní operace
@@ -25,14 +25,14 @@ sessions:
         url: https://pydatacz.github.io/pyladies-kurz/pydata/visualization-basics/
 
   - title: Statistika jedné proměnné a časové řady
-    date: 29.9.2025
+    date: 2025-09-29
     slug: 3-statistika-jedne-promenne-a-casove-rady
     materials:
       - attachment: Explorativní analýza a statistika jedné proměnné
         url: https://pydatacz.github.io/pyladies-kurz/pydata/eda-univariate-timeseries/
 
   - title: Explorativní datová analýza a více zdrojů / proměnných
-    date: 6.10.2025
+    date: 2025-10-06
     slug: 4-explorativni-datova-analyza-a-vice-zdroju-promennych
     materials:
       - attachment: Pandas - spojování tabulek
@@ -41,14 +41,14 @@ sessions:
         url: https://pydatacz.github.io/pyladies-kurz/pydata/pandas-correlations/
 
   - title: Explorativní datová analýza - agregace a transformace
-    date: 13.10.2025
+    date: 2025-10-13
     slug: 5-explorativni-datova-analyza-agregace-a-transformace
     materials:
       - attachment: EDA 5, Pokročilejší manipulace a agregace
         url: https://pydatacz.github.io/pyladies-kurz/pydata/pandas-groupby/
 
   - title: Strojové učení - úvod, regrese
-    date: 20.10.2025
+    date: 2025-10-20
     slug: 6-strojove-uceni-uvod-regrese
     materials:
       - attachment: Úvod do strojového učení
@@ -61,7 +61,7 @@ sessions:
         url: https://pydatacz.github.io/pyladies-kurz/pydata/regression-resume/
 
   - title: Strojové učení - Scikit-learn, ML workflow
-    date: 27.10.2025
+    date: 2025-10-27
     slug: 7-scikit-learn-ml-workflow
     materials:
       - attachment: Knihovna Scikit-learn
@@ -72,7 +72,7 @@ sessions:
         url: https://pydatacz.github.io/pyladies-kurz/pydata/scikitlearn-resume/
 
   - title: Strojové učení - klasifikační úlohy
-    date: 3.11.2025
+    date: 2025-11-03
     slug: 8-strojove-uceni-klasifikacni-ulohy
     materials:
       - attachment: Úvod klasifikace
@@ -83,14 +83,14 @@ sessions:
         url: https://pydatacz.github.io/pyladies-kurz/pydata/classification-resume/
 
   - title: Analýza hlavních komponent (PCA)
-    date: 10.11.2025
+    date: 2025-11-10
     slug: 9-analyza-hlavnich-komponent-pca
     materials:
       - attachment: Analýza hlavních komponent (PCA)
         url: https://pydatacz.github.io/pyladies-kurz/pydata/pca/
 
   - title: Interaktivní vizualizace a aplikace
-    date: 24.11.2025
+    date: 2025-11-24
     slug: 10-interaktivni-vizualizace-a-aplikace
     materials:
       - attachment: Interaktivní vizualizace a aplikace I.

--- a/data/2025_pydata_praha_autumn/course.yaml
+++ b/data/2025_pydata_praha_autumn/course.yaml
@@ -1,0 +1,23 @@
+id: pydata-2024-praha-podzim
+naucse_api_url: https://naucse.python.cz/v0/2024/pydata-praha-podzim.json
+end_date: 2024-12-24
+tasks_by_lesson_slug:
+
+  "pydata/notebook":
+  - file: tasks/eda_1.yaml
+  "pydata/pandas_types":
+  - file: tasks/eda_2.yaml
+  "pydata/eda-univariate-timeseries":
+  - file: tasks/eda_3.yaml
+  "pydata/pandas_correlations":
+  - file: tasks/eda_4.yaml
+  "pydata/pandas_groupby":
+  - file: tasks/eda_5.yaml
+  "pydata/regression_exercises":
+  - file: tasks/ml_1.yaml
+  "pydata/classification_metrics":
+  - file: tasks/ml_3.yaml
+  "pydata/pca":
+  - file: tasks/pca.yaml
+  "pydata/dashboards":
+  - file: tasks/dashboards.yaml

--- a/data/2025_pydata_praha_autumn/course.yaml
+++ b/data/2025_pydata_praha_autumn/course.yaml
@@ -1,6 +1,6 @@
-id: pydata-2024-praha-podzim
-naucse_api_url: https://naucse.python.cz/v0/2024/pydata-praha-podzim.json
-end_date: 2024-12-24
+id: pydata-2025-praha-podzim
+naucse_api_url: https://naucse.python.cz/v0/2025/pydata-praha-podzim.json
+end_date: 2025-12-24
 tasks_by_lesson_slug:
 
   "pydata/notebook":

--- a/data/2025_pydata_praha_autumn/course.yaml
+++ b/data/2025_pydata_praha_autumn/course.yaml
@@ -1,23 +1,97 @@
 id: pydata-2025-praha-podzim
 naucse_api_url: https://naucse.python.cz/v0/2025/pydata-praha-podzim.json
 end_date: 2025-12-24
-tasks_by_lesson_slug:
 
-  "pydata/notebook":
-  - file: tasks/eda_1.yaml
-  "pydata/pandas_types":
-  - file: tasks/eda_2.yaml
-  "pydata/eda-univariate-timeseries":
-  - file: tasks/eda_3.yaml
-  "pydata/pandas_correlations":
-  - file: tasks/eda_4.yaml
-  "pydata/pandas_groupby":
-  - file: tasks/eda_5.yaml
-  "pydata/regression_exercises":
-  - file: tasks/ml_1.yaml
-  "pydata/classification_metrics":
-  - file: tasks/ml_3.yaml
-  "pydata/pca":
-  - file: tasks/pca.yaml
-  "pydata/dashboards":
-  - file: tasks/dashboards.yaml
+sessions:
+
+  - title: Představení, Jupyter notebook, základy pandas
+    date: 15.9.2025
+    slug: 1-predstaveni-jupyter-notebook-zaklady-pandas
+    materials:
+      - attachment: Instalace
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/install/
+      - attachment: Jupyter Notebook intro
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/notebook/
+      - attachment: Knihovna pandas a základní manipulace s tabulkovými daty
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/pandas-core/
+
+  - title: Datové typy a základy vizualizace v pandas
+    date: 22.9.2025
+    slug: 2-datove-typy-zaklady-vizualizace
+    materials:
+      - attachment: Pandas - datové typy a základní operace
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/pandas-types/
+      - attachment: Základy vizualizace
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/visualization-basics/
+
+  - title: Statistika jedné proměnné a časové řady
+    date: 29.9.2025
+    slug: 3-statistika-jedne-promenne-a-casove-rady
+    materials:
+      - attachment: Explorativní analýza a statistika jedné proměnné
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/eda-univariate-timeseries/
+
+  - title: Explorativní datová analýza a více zdrojů / proměnných
+    date: 6.10.2025
+    slug: 4-explorativni-datova-analyza-a-vice-zdroju-promennych
+    materials:
+      - attachment: Pandas - spojování tabulek
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/pandas-joins/
+      - attachment: Pandas - vztahy mezi více proměnnými
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/pandas-correlations/
+
+  - title: Explorativní datová analýza - agregace a transformace
+    date: 13.10.2025
+    slug: 5-explorativni-datova-analyza-agregace-a-transformace
+    materials:
+      - attachment: EDA 5, Pokročilejší manipulace a agregace
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/pandas-groupby/
+
+  - title: Strojové učení - úvod, regrese
+    date: 20.10.2025
+    slug: 6-strojove-uceni-uvod-regrese
+    materials:
+      - attachment: Úvod do strojového učení
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/intro-regression/
+      - attachment: Regresní metriky
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/regression-metrics/
+      - attachment: Příklady pro zamyšlení
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/regression-exercises/
+      - attachment: Regrese - Co bych měla po této lekci znát ..
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/regression-resume/
+
+  - title: Strojové učení - Scikit-learn, ML workflow
+    date: 27.10.2025
+    slug: 7-scikit-learn-ml-workflow
+    materials:
+      - attachment: Knihovna Scikit-learn
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/scikitlearn-api/
+      - attachment: Implementace úlohy z domácího úkolu
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/homework-revisited/
+      - attachment: Scikitlearn - Co bych měla po této lekci znát ..
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/scikitlearn-resume/
+
+  - title: Strojové učení - klasifikační úlohy
+    date: 3.11.2025
+    slug: 8-strojove-uceni-klasifikacni-ulohy
+    materials:
+      - attachment: Úvod klasifikace
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/intro-classification/
+      - attachment: Klasifikační metriky
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/classification-metrics/
+      - attachment: Klasifikace - Co bych měla po této lekci znát ..
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/classification-resume/
+
+  - title: Analýza hlavních komponent (PCA)
+    date: 10.11.2025
+    slug: 9-analyza-hlavnich-komponent-pca
+    materials:
+      - attachment: Analýza hlavních komponent (PCA)
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/pca/
+
+  - title: Interaktivní vizualizace a aplikace
+    date: 24.11.2025
+    slug: 10-interaktivni-vizualizace-a-aplikace
+    materials:
+      - attachment: Interaktivní vizualizace a aplikace I.
+        url: https://pydatacz.github.io/pyladies-kurz/pydata/dashboards/

--- a/data/2025_pydata_praha_autumn/tasks/dashboards.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/dashboards.yaml
@@ -1,0 +1,17 @@
+tasks:
+
+- section:
+    markdown: |
+      Použij předpřipravenou kostru Fishboardu z [Githubu](https://github.com/coobas/pydataladies-dashboard) a naklonuj si jí k sobě na počítač příkazem `git clone https://github.com/coobas/fishboard.git`. Doporučujeme pro ni také vytvořit samostatné virtuální prostředí viz [návod tady](https://naucse.python.cz/2019/pyladies-ostrava-podzim/beginners/venv-setup/)
+
+- id: dashboards_01
+  markdown: |
+    Přidej do "fishboardu" naši předchozí aplikaci pro načítání a zobrazování dat. Asi bude potřeba někde místo `st.` použít `col1`.
+
+- id: dashboards_02
+  markdown: |
+    Přidej do fishboardu možnost klasifikace a / nebo klastrování (PCA).
+
+- id: dashboards_03
+  markdown: |
+    Spusť upravenou aplikaci na Streamlit Cloud a zkopíruj sem odkaz. Jako bonus můžeš dát svůj kód k dispozici na Githubu.

--- a/data/2025_pydata_praha_autumn/tasks/eda_1.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/eda_1.yaml
@@ -1,0 +1,45 @@
+tasks:
+
+- section:
+    markdown: |
+      Template s úkoly na DeepNote si zduplikuj [TADY](https://deepnote.com/workspace/barbora-profantova-d152-f93a3df8-5309-45f1-8561-ff1eaf52f568/project/pydatakurzpodzim2022eda1tvojejmeno-Duplicate-d63ce885-8e9d-42fa-92f2-f0a97324a9b3/notebook/pydata_eda1_tvoje_jmeno-61e45d1c9aa44e2194c9d63ab52ca182).
+
+- id: eda1_00
+  markdown: |
+    Odkaz na tvůj notebook na DeepNote (nezapomeň změnit práva na "Edit" a přejmenovat soubor):
+
+- id: eda1_01
+  markdown: |
+    Vytvoř objekt Series, který bude obsahovat seznam tvých oblíbených filmů a přidej mu index a jméno. Pak přidej kód, který vypíše počet prvků Series.
+
+- id: eda1_02
+  markdown: |
+    Použij Series vytvořenou v předchozím úkolu a vytvoř DataFrame, která bude obsahovat navíc jméno režiséra či režisérky a rok premiéry.
+
+- id: eda1_03
+  markdown: |
+    Vytvoř tabulku malé násobilky jako DataFrame (t.j. index i sloupce tvoří čísla 1-10, na průsečících je hodnota součinu).
+
+- id: eda1_04
+  markdown: |
+    Napiš funkci `multiplication_table(n)`, která vytvoří čtvercovou DataFrame s násobilkou s volitelným počtem řádků a sloupců `n`.(Stačí jen malinko adaptovat předchozí příklad).
+
+- id: eda1_05
+  markdown: |
+    Použij tabulku pokémonů z hodiny. Pomocí tzv. indexerů zjisti: jaké hodnoty útoku a obrany má pokémon pikachu?
+
+- id: eda1_06
+  markdown: |
+    Příště budeme pracovat s tabulkou zemí světa. Stáhni si tabulku jako csv z [této adresy](https://raw.githubusercontent.com/janpipek/data-pro-pyladies/master/data/countries.csv) a:
+    
+    - podívej se, jaké obsahuje sloupce
+    - zkus jí nastavit index podle jména a seřaď řádky podle indexu
+    - vypiš řádky se zeměmi začínajícími na “Slo” a (subjektivně) je porovnej.
+
+- section:
+    markdown: |
+      Následující projekt je volitelný. Nemáš-li čas, klidně ho přeskoč.
+
+- id: eda1_07
+  markdown: |
+    Pomocí unicodových symbolů (♔♕♖♗♘♙♚♛♜♝♞♟) vytvoř šachovnici jako DataFrame (poněkud pracné, ale estetické). Pojmenuj sloupce i řádky (barvu polí neřeš, byť i k tomu se můžeme později dostat).

--- a/data/2025_pydata_praha_autumn/tasks/eda_2.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/eda_2.yaml
@@ -1,0 +1,42 @@
+tasks:
+
+- section:
+    markdown: |
+      Template s úkoly na DeepNote si zduplikuj [TADY](https://deepnote.com/workspace/pydata23-883d73ac-8ab0-4b61-a477-5fa9b206edd2/project/pydatakurzpodzim2023eda2tvojejmeno-dc6fb653-863b-44c8-8749-d0e58587d1f3/notebook/pydata_eda2-629e8d02d9b2416b94fea12cbd246277).
+
+- id: eda2_00
+  markdown: |
+    Odkaz na tvůj notebook na DeepNote (nezapomeň změnit práva na "Edit" a přejmenovat soubor):
+
+- id: eda2_01
+  markdown: |
+    Podle Keplerových zákonů by pro všechny planety měl být konstantní poměr mezi třetí mocninou velké poloosy elipsy oběžné dráhy a druhou mocninou oběžné doby. Dokážeš to ověřit pomocí tabulky `planety`, kterou jsme si v hodině vytvořili?
+
+- id: eda2_02
+  markdown: |
+    Vytvoř vhodný graf, který velkou poloosu elipsy a oběžnou dobu spojuje.
+
+- section:
+    markdown: |
+      Použij tabulku `countries` z hodiny a:
+
+- id: eda2_03
+  markdown: |
+    Přidej do tabulky zemí sloupce `women_overweight`, `men_overweight`, kde nadváhou zástupců příslušného pohlaví myslíme průměrné bmi > 25.
+
+- id: eda2_04
+  markdown: |
+    Zjisti, v jakých zemích, které NEpatří do `low_income` group, mají průměrně méně než 3000 kalorií na den.
+
+- id: eda2_05
+  markdown: |
+    Napiš kód, který vytvoří graf bmi mužů a bmi žen v zemích EU. Zkus si pohrát i s parametry - nastav figsize, barvu...
+
+- section:
+    markdown: |
+      Poslední projekt je volitelný. Nemáš-li čas, klidně ho přeskoč.
+
+- id: eda2_06
+  markdown: |
+    Najdi si nějaká data, udělej z nich vizualizaci a postni ji na Slack do kanálu #projekty s informací, odkud jsi data bral/a a čeho se týkají. Pokud nevíš, zajímavá data najdeš například [zde](https://veekaybee.github.io/2018/07/23/small-datasets/).
+

--- a/data/2025_pydata_praha_autumn/tasks/eda_3.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/eda_3.yaml
@@ -1,0 +1,44 @@
+tasks:
+
+- section:
+    markdown: |
+      Template s úkoly na DeepNote si zduplikuj [TADY](https://deepnote.com/workspace/pydata23-883d73ac-8ab0-4b61-a477-5fa9b206edd2/project/pydatakurzpodzim2023eda3tvojejmeno-025c5104-04ec-49b8-8743-063b33df80c3/notebook/EDA3%202022%20podzim%20-%20zad%C3%A1n%C3%AD-6182d2c151b7457fad967088d7689cc5).
+
+
+- id: eda3_00
+  markdown: |
+    Odkaz na tvůj notebook na DeepNote a případné poznámky(nezapomeň změnit práva na "Edit" a přejmenovat soubor):
+
+- id: eda3_01
+  markdown: |
+    Načti data pro alespoň 3 stanice pomocí funkce `load_chmi_excel_files`. 
+    Pomocí `sns.lineplot` vykresli rychlost větru v červnu, červenci a srpnu 2021.
+
+    Zkuste vypozorovat nějaké rozdíly mezi stanicemi. Poté použijte `sns.boxplot` nebo `px.box` a ověřte, jestli jsou vypozorované rozdíly vidět.
+
+
+- id: eda3_02
+  markdown: |
+    Vytvoř graf, který porovná vývoj ročních úhrnů srážek (tj. vždy suma srážek za daný rok - na to se ti bude hodit `resample`) ve dvou libovolných stanicích.
+
+- id: eda3_03
+  markdown: |
+    Zjisti, ve které z těchto stanic byl nejteplejší den (den s nejvyšší maximální teplotou) v roce 2010 a který den to byl.
+
+- id: eda3_04
+  markdown: |
+    Podnikavý zemědělec by rád začal pěstovat novou plodinu, která ale v daném roce plodí jen pokud je splněno:
+
+    * maximálně 35 % dní klesne minimální denní teplota pod nulu,
+    * alespoň 40 % dní svítí slunce více než pět hodin,
+    * průměrná vlhkost vzduchu za celý rok je větší než 70 %.
+
+    Doporučila bys na pěstování této plodiny na základě počtu let v historii, ve kterých byly tyto podmínky splněny, Ruzyni nebo Mošnov? Jak velkou pravděpodobnost má zemědělec, že mu další rok bude tato nová plodina plodit?
+
+    Tip: Pro řešení úlohy se hodí `resample` a `quantile`.
+
+- id: eda3_05
+  markdown: |
+    Který z ledových mužů je nejmrazivější? Pankrác (12. 5.), Servác (13. 5.) nebo Bonifác (14. 5.)? 
+    
+    Zjisti to porovnáním mediánů minimálních teplot těchto dní, pro výpočet ale použij pouze dny kdy mrzlo, tj. kdy byla minimální teplota pod nulou.

--- a/data/2025_pydata_praha_autumn/tasks/eda_4.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/eda_4.yaml
@@ -1,0 +1,37 @@
+tasks:
+
+- section:
+    markdown: |
+      Template s úkoly na DeepNote si zduplikuj [TADY](https://deepnote.com/workspace/pydata23-883d73ac-8ab0-4b61-a477-5fa9b206edd2/project/pydatakurzpodzim2023eda4tvojejmeno-fc9a7d0e-c9e5-4840-a603-ff3deea65e04/notebook/pydata_eda4-8b7a9d9af7c3436286a354aa8aa88193).
+
+- id: eda4_00
+  markdown: |
+    Odkaz na tvůj notebook na DeepNote (nezapomeň změnit práva na "Edit" a přejmenovat soubor):
+
+- id: eda4_01
+  markdown: |
+    Použij data z tabulky `countries` a spočti korelační koeficienty mezi jednotlivými sloupci. Slovně popiš, které hodnoty tě zaujaly a proč.
+
+- id: eda4_02
+  markdown: |
+    Dál pracuj s tabulkou `countries` a spočítej průměrnou dobu dožití (`life_expectancy`) pro jednotlivé příjmové skupiny (`income_groups`) a regiony (`world_6region`). (Nápověda: vzpomeň si, jak jsme v minulé hodině analyzovali vztah mezi dvěma kategorickými proměnnými).
+
+- id: eda4_03
+  markdown: |
+    Pomocí jedné funkce graficky zobraz vztahy všech dvojic těchto proměnných: `life_expectancy`, `life_expectancy_male` a `life_expectancy_female` v tabulce `countries`. Porovnej s korelačními koeficienty a popřemýšlej, proč vycházejí jinak, než by někdo mohl čekat.
+
+- id: eda4_04
+  markdown: |
+    Použij data o filmech z minulé hodiny (`movies_complete`) a graficky zobraz distribuci příjmů (`lifetime_gross`) těchto filmových studií: _['BV', 'WB', 'Par.', 'Uni.', 'Fox', 'Sony', 'DW', 'NL', 'FoxS', 'Col.']_. Nápověda - pro filtraci studií použij metodu `isin()` viz [dokumentace](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.isin.html).
+
+- id: eda4_05
+  markdown: |
+    Stáhni si tabulku `OMdb_mojo_clean.csv` z [této adresy](https://github.com/zacharyang/movies-project/blob/master/data/clean/OMdb_mojo_clean.csv) a udělej join s finální tabulkou z minulé hodiny. Potom spočítej cross-korelace všech hodnocení ve výsledném datasetu.
+
+- id: eda4_06
+  markdown: |
+    Spočtěte korelační koeficient pro oběžnou poloosu a oběžnou dobu a pomocí korelace dokažte, že existuje vztah mezi těmito veličinam.
+
+- id: eda4_07
+  markdown: |
+    Poslední úkol je spíše k zamyšlení (nemusíš psát kód): Zjisti, které z TOP 20 filmů z [oficiálního žebříčku IMDB](https://www.imdb.com/chart/top/?ref_=nv_mv_250) nejsou v naší finální tabulce z minulé hodiny. Dokážeš zdůvodnit proč?

--- a/data/2025_pydata_praha_autumn/tasks/eda_5.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/eda_5.yaml
@@ -1,0 +1,38 @@
+tasks:
+
+- section:
+    markdown: |
+      Template s úkoly na DeepNote si zduplikuj [TADY](https://deepnote.com/workspace/pydata23-883d73ac-8ab0-4b61-a477-5fa9b206edd2/project/pydatakurzpodzim2023eda5tvojejmeno-9da9a1e4-af84-4f1b-80b2-e2f900b2908b/notebook/pydata_eda5-73f411090a7d4471b442120e6b7ba098).
+
+- section:
+    markdown: |
+      Česká správa sociálního zabezpečení (ČSSZ) nabízí spoustu dat ohledně zaměstnanců, zaměstnavatelů, pojištění, důchodů atd. My se podíváme na data o OSVČ a jejich statistiky napříč Českem. Načti si do DataFramu CSV z [této adresy](https://data.cssz.cz/dump/prehled-o-celkovem-poctu-osvc-podle-okresu.csv). 
+      Budou nás zajímat sloupce `datum`, `okres_kod`, `okres`, `vykonavana_cinnost_hlavni`, zbytek můžeš zahodit. Možná se ti bude hodit, když `datum` budeš brát fakt jako datum.
+
+- id: eda5_00
+  markdown: |
+    Odkaz na tvůj notebook na DeepNote (nezapomeň změnit práva na "Edit" a přejmenovat soubor):
+
+- id: eda5_01
+  markdown: |
+    Pro každý okres je v tabulce několik desítek pozorování v čase (poznáš podle sloupce `datum`). Pro každé datum zjisti, kolik řádků v DataFramu je - mělo by to odpovídat počtu okresů.
+
+- id: eda5_02
+  markdown: |
+    Pro každé datum zjisti, kolik byl celkový počet lidí s živností jako hlavní činností (`vykonavana_cinnost_hlavni`).
+
+- id: eda5_03
+  markdown: |
+    Z výsledku předchozího úkolu zkus spočítat, kolik byl každý rok průmerný počet OSVČ (hlavních). Tj. pokud ti v březnu 2019 vyšlo 500000, v září 600000 a v prosinci 650000, budeš chtít mít ve výsledku pro řádek s rokem 2019 hodnotu zhruba 583333.
+
+- id: eda5_04
+  markdown: |
+    Zkus spočítat průměrný počet vykonávaných hlavních činností za rok a okres. Výsledek pak otoč (pivotuj), abys měla v řádcích okresy, ve sloupcích jednotlivé roky (hodnota bude vždy onen průměr pro daný okres a rok). Jakmile bude dopivotováno, zkus dataframe opět převést na ten dlouhý (tj. rok bude pouze jeden sloupec, ne co rok, to sloupec).
+
+- id: eda5_05
+  markdown: |
+    Najdi datum nejnovějších pozorování (nejnovější `datum`) a vyfiltruj si náš dataframe do nového, který bude obsahovat jen pozorování z této doby. (Měl by mít 77 řádků, jeden pro každý okres.)
+
+- id: eda5_06
+  markdown: |
+    V tomto malém dataframu z předchozího úkolu si můžeš všimnout, že počet OSVČ se celkem dramaticky liší mezi okresy. Podívej se na rozložení počtu živností, stačí rovnoměrné na 5 intervalů (tj. všechny intervaly jsou stejné dlouhé, ale můžou mít dost rozdílný počet řádků). Některé intervaly mají nula řádků - co se stalo? Proč tomu tak je? Navrhla bys lepší rozdělení dat?

--- a/data/2025_pydata_praha_autumn/tasks/ml_1.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/ml_1.yaml
@@ -1,0 +1,19 @@
+tasks:
+
+- id: ml1_01
+  markdown: |
+    
+    Prohlédni si obrázek níže a rozmysli si odpovědi na následující otázky. Nic neprogramuj, ale zkus své myšlenky sepsat sem do odevzdávátka - na začátku další hodiny se o tom pobavíme a poté vše společně naprogramujeme.
+    
+    <img src="/static/tasks/handout_pydata_prg_images/ryby.png" alt="ryby" style="max-width: 100%; max-height: 639px">
+      
+    Data obsahují údaje o rybách. Druh, váhu, rozměry (délek je více, jsou měřeny různě napříč rybou). Cílem je predikovat váhu ryby. (Váha se rozbila, ale metr a počítač máme.) 
+
+    Rozmysli si a napiš slovně (nic nemusíš programovat) jako odpověď na tento úkol:
+
+    - Které sloupečky využijeme? 
+    - Co budou příznaky (vstupní proměnné) a co výstup modelu?
+    - Jsou tam nějaké hodnoty, které budeme chtít použít a nejsou to čísla? Co s nimi uděláme?
+    - Jakou použijeme metriku?
+    - Jak zjistíme, zda nám model rozumně funguje?
+    - Popiš celý proces, který budeš muset udělat (od načtení dat po zhodnocení výsledku). 

--- a/data/2025_pydata_praha_autumn/tasks/ml_3.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/ml_3.yaml
@@ -1,0 +1,24 @@
+tasks:
+
+- id: ml3_01
+  markdown: |
+    V 1. úkolu se budeš snažit vylepšit model na klasifikaci vín.
+    Celé zadání najdeš v tomto [DeepNote notebooku](https://deepnote.com/workspace/PyDataLadies-Jaro-2021-0579e7e7-50f6-4c4b-ba8a-1b39758bff4d/project/Uloha-ML-1-Podzim-2022-vino-8b4b6edf-5b40-40d7-8865-ba7470350fb5).
+    
+    Notebook si klasicky zduplikuj a sem poté zkopíruj odkaz (nezapomeň změnit práva na "Edit" a přejmenovat soubor).
+
+- id: ml3_02
+  markdown: |
+    V 2. úkolu budeš vytvářet model, který bude dle charakteristiky příšery predikovat její magickou sílu.
+    Celé zadání najdeš v tomto [DeepNote notebooku](https://deepnote.com/workspace/PyDataLadies-Jaro-2021-0579e7e7-50f6-4c4b-ba8a-1b39758bff4d/project/Uloha-ML-2-Podzim-2022-prisery-3a72c947-11c1-4eec-84c1-468ad97a6c13).
+    
+    Notebook si klasicky zduplikuj a sem poté zkopíruj odkaz (nezapomeň změnit práva na "Edit" a přejmenovat soubor).
+
+- id: ml3_03
+  markdown: |
+    Ve 3. úkolu budeš klasifikovat bankovky na pravé a falešné s cílem minimalizovat počet falešně negativních bankovek.
+
+    Celé zadání najdeš v tomto [DeepNote notebooku](https://deepnote.com/workspace/PyDataLadies-Jaro-2021-0579e7e7-50f6-4c4b-ba8a-1b39758bff4d/project/Uloha-ML-3-Podzim-2022-bankovky-e7982c85-dbec-4cde-b438-2b6d784fb9c9).
+    
+    Notebook si klasicky zduplikuj a sem poté zkopíruj odkaz (nezapomeň změnit práva na "Edit" a přejmenovat soubor).
+

--- a/data/2025_pydata_praha_autumn/tasks/pca.yaml
+++ b/data/2025_pydata_praha_autumn/tasks/pca.yaml
@@ -1,0 +1,30 @@
+tasks:
+
+- section:
+    markdown: |
+      Použij databázi Gapminder se statistikami o jednotlivých státech světa a pokus se aplikovat, co ses v hodině o PCA naučila.
+      Template s úkoly na DeepNote si zduplikuj [TADY](https://deepnote.com/workspace/PyDataLadies-Jaro-2021-0579e7e7-50f6-4c4b-ba8a-1b39758bff4d/project/pydatakurzpodzim2022pcatvojejmeno-0dc81071-fb52-4fc1-a782-ca5e9cf56df8).
+
+- id: pca_00
+  markdown: |
+    Odkaz na tvůj notebook na DeepNote (nezapomeň změnit práva na "Edit" a přejmenovat soubor):
+
+- id: pca_01
+  markdown: |
+    Spočítej, kolik je v každém sloupci chybějících hodnot `(countries.isnull().sum(axis = 0))`. Zvaž, které sloupce chceš pro PCA použít. Nepoužívej sloupce s vysokým podílem chybějících pozorování, ani sloupce, které pro porovnávání států nedávají dobrý smysl (např. protože odrážejí velikost státu, nikoli jeho charakteristiky).
+
+- id: pca_02
+  markdown: |
+    Do tabulky s vybranými sloupci doplň chybějící hodnoty pomocí `SimpleImputer` z balíčku sklearn.
+
+- id: pca_03
+  markdown: |
+    Normalizuj data pomocí `StandardScaler` a spočítej první dvě komponenty `PCA`. Vykresli data do souřadnicového grafu (scatter plot). Jsou země EU blízko sebe? Tvoří shluk?
+
+- id: pca_04
+  markdown: |
+    Dokážeš najít interpretaci pro PCA1 a PCA2 (první dvě komponenty PCA)? Pomoci může, když si nakreslíš interaktivní graf zobrazující jméno země (balíček `plotly`). Zkus si též spočítat, nakolik jednotlivé sloupečky z původní tabulky přispívají ke koeficientům (loadings) PCA1 a PCA2.
+
+- id: pca_05
+  markdown: |
+    Pokus se navrhnout, jak by šly do PCA zahrnout kategoriální veličiny, za předpokladu, že počet jejich kategorií není příliš velký (např. indikátor `is_eu`, zda je země v EU, nebo kontinent `world_6region`).


### PR DESCRIPTION
- [x] Opravit url adresy na materialy
- [x] ~Opravit url na naucse api - 2025 tam asi jeste neni, 2024 je [tady](https://naucse.python.cz/2024/pydata-praha-podzim/)~ – Aha, tak na naucse to [nebude](https://pydata-kurz-praha.slack.com/archives/GSPS5BFML/p1755972218961749), nebo tam bude jen odkaz, materiály jsou nově na https://pydatacz.github.io/pyladies-kurz/, ale nejsou tam datumy lekcí apod.
- [x] Doplnit datumy lekcí a další metadata do yaml souborů, protože si to odevzdávátko nemůže načíst z naučse
